### PR TITLE
docs: add git guidance

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,14 @@
+# Guidance for contributing to `ctrl-next`
+
+## Welcome
+
+Thank you for being interested in contributing to this project!
+Please see the information below for guidance on how to get set up with a suitable development environment, and how to collaborate with the project team via GitHub.
+
+## Git + GitHub
+
+Please create issues, and develop work in branches named using the pattern: `feature/issue-##-short-description`.
+Please use [conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) as these can be used with automated versioning tools.
+Submit [pull requests](https://docs.github.com/en/pull-requests) to the `dev` branch (this is the default branch for this repository).
+We are using branch protection rules so that all work must be reviewed before it can be merged into the `dev` branch.
+Code review helps improve code quality and performance.


### PR DESCRIPTION
Relates to #1 

Adds `docs/CONTRIBUTING.md` with guidance for collaborating via Github