### PR TITLE
Specify timezone in CronJob

### DIFF
--- a/.helm/ctrl/templates/cron.yaml
+++ b/.helm/ctrl/templates/cron.yaml
@@ -5,6 +5,7 @@ kind: CronJob
 metadata:
   name: demo-reset
 spec:
+  timeZone: "Australia/Sydney"
   schedule: "0 0 * * *"
   jobTemplate:
     spec:


### PR DESCRIPTION
Resolves #333 by setting timezone in CronJob template