### PR TITLE
Move login button to top of Registration page

### DIFF
--- a/application/user-client/src/pages/Register.tsx
+++ b/application/user-client/src/pages/Register.tsx
@@ -132,6 +132,11 @@ export default function Register() {
                 alt="logo"
               />
             </Box>
+            <Box sx={{ mt: 3 }}>
+              <Button component={Link} to="/login">
+                Already registered? Log In
+              </Button>
+            </Box>
             {Object.keys(errors) && <Typography>{}</Typography>}
             <Box sx={{ display: 'flex', flexWrap: 'wrap' }}>
               <TextField
@@ -480,11 +485,6 @@ export default function Register() {
               Register
             </Button>
           </form>
-          <Box sx={{ mt: 3 }}>
-            <Button component={Link} to="/login">
-              Already registered? Log In
-            </Button>
-          </Box>
         </Card>
       </Container>
     </>


### PR DESCRIPTION
Resolves #534 

If a user is already registered and is invited to a new study, currently email sends them to registration page. There is a 'already registered? log in here' button, but it is at the bottom of the page. If they try to register they get an error as their email name dob is not unique.

The plan for the future is to send a different email to people who are already registered, but in the interim this PR moves the 'already registered' button to the top of the registration page.