### PR TITLE
671 config bug

### DIFF
--- a/application/backend/config/config.json5.template
+++ b/application/backend/config/config.json5.template
@@ -8,7 +8,7 @@
       clientSecret: '',
     },
   ],
-  disableAdminPasswordLogin: true,
+  disableAdminPasswordLogin: false,
   otp: false,
   inviteExpiryDays: 7,
   smtp: {


### PR DESCRIPTION
Resolves #671 by adding a comma

Also, changes default setting for `disableAdminPasswordLogin` to false. I figure most people using this template will be wanting to run things locally with password to trial the app. Happy to revert this change if changing this template setting has unintended consequences.