### PR TITLE
Defer minimatch til next month

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -30,6 +30,6 @@ ignore:
   SNYK-JS-MINIMATCH-15309438:
     - '*':
         reason: 'Requires major ESLint upgrade (v8 to v9/10)'
-        expires: 2026-02-25T00:00:00.000Z
+        expires: 2026-03-25T00:00:00.000Z
         created: 2026-02-20T00:00:38.018Z
 patch: {}


### PR DESCRIPTION
Merging a release back to dev failed with a snyk alert. I'm deferring the fix as it involves a non-trivial cascade of library updates.

I've created an issue #791 to do this work before 2026-03-25.

This PR amends a snyk rule to stop this from blocking CI.