### PR TITLE
Add tunnel-through-iap to workflow action

### DIFF
--- a/.github/actions/run-vm-command/action.yml
+++ b/.github/actions/run-vm-command/action.yml
@@ -43,9 +43,10 @@ runs:
         echo "Running command on VM: ${{ inputs.vm_instance }}"
         echo "Zone: ${{ inputs.vm_zone }}"
         echo "Command: ${{ inputs.command }}"
-        
+
         gcloud --quiet beta compute ssh "${{ inputs.vm_instance }}" \
           --zone="${{ inputs.vm_zone }}" \
+          --tunnel-through-iap \
           --command="${{ inputs.command }}"
 
 branding:

--- a/.github/workflows/restart-deployments.yml
+++ b/.github/workflows/restart-deployments.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Restart deployments on VM
-        uses: Garvan-Data-Science-Platform/ctrl/.github/actions/run-vm-command@main
+        uses: ./.github/actions/run-vm-command
         with:
           project_id: 'ctrl-358804'
           vm_instance: ctrl-${{ inputs.environment }}


### PR DESCRIPTION
Adds tunnel-though-iap to CI action ssh command, and changes to relative path for ci workflow action (to prevent having to wait for the change to make it to main).

resolves #805 