### PR TITLE
Add tunnel-through-iap to CI ssh and scp

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,10 +124,12 @@ jobs:
           gcloud --quiet beta compute ssh ctrl-dev \
             --zone=australia-southeast1-a \
             --project=ctrl-358804 \
+            --tunnel-through-iap \
             --command="mkdir -p /opt/ctrl/chart && rm -rf /opt/ctrl/chart/{*,.*} 2>/dev/null || true" && \
           gcloud --quiet beta compute scp --recurse .helm/ctrl/ \
             ctrl-dev:/opt/ctrl/chart/ \
             --zone=australia-southeast1-a \
+            --tunnel-through-iap \
             --project=ctrl-358804
 
   restart-dev-deployments:


### PR DESCRIPTION
adds `--tunnel-through-iap` to a couple of places in CI build workflow where there are gcloud ssh and scp commands.