### PR TITLE
Try to address merge conflict when releasing

### DIFF
--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -51,7 +51,13 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
           git checkout main
-          git merge ${{ steps.get_commit.outputs.commit_sha }}
+          git merge ${{ steps.get_commit.outputs.commit_sha }} || {
+            echo "Merge conflict detected. Resolving Chart.yaml to release version."
+            git checkout ${{ steps.get_commit.outputs.commit_sha }} -- .helm/ctrl/Chart.yaml
+            git add .helm/ctrl/Chart.yaml
+            git commit -m "Auto-resolved Chart.yaml conflict during release promotion"
+          }
+
           git push origin main
 
       - name: Create and push release tag


### PR DESCRIPTION
This PR adds conditional logic to handle merge conflicts between UAT and main due to differences in CTRL version number in .helm/ctrl/Chart.yaml.

Here is an example of a CI run where it failed: https://github.com/Garvan-Data-Science-Platform/ctrl/actions/runs/24227148423/job/70730602643 (before this PR)

Here is an example where it ran successfully: https://github.com/Garvan-Data-Science-Platform/ctrl/actions/runs/24227744876
