### PR TITLE
Store emails in lowercase

### DIFF
--- a/application/admin-client/cypress/e2e/invites.cy.js
+++ b/application/admin-client/cypress/e2e/invites.cy.js
@@ -59,6 +59,34 @@ describe('', () => {
       .should('contain.text', 'email2@g.co')
   })
 
+  it('Uppercase emails are not added when typing', () => {
+    cy.visit('/participants')
+    cy.get('[data-cy="invite-button"]').click()
+    cy.get('[data-cy="send-button"]').should('be.disabled')
+    cy.get('[data-cy="email-field"]').type('tom@example.com').type('{enter}')
+    cy.get('[data-cy="recipients-list"]').should('contain.text', 'tom@example.com')
+    cy.get('[data-cy="email-field"]').clear().type('ToM@ExAmPlE.cOm').type('{enter}')
+    cy.get('[data-cy="recipients-list"]').should('not.contain.text', 'ToM@ExAmPlE.cOm')
+    // try inverse
+    cy.get('[data-cy="remove-button"]').first().click()
+    cy.get('[data-cy="email-field"]').clear().type('ToM@ExAmPlE.cOm').type('{enter}')
+    cy.get('[data-cy="recipients-list"]').should('contain.text', 'tom@example.com')
+    cy.get('[data-cy="recipients-list"]').should('not.contain.text', 'ToM@ExAmPlE.cOm')
+  })
+
+  it('Uppercase emails are not pasted', () => {
+    cy.visit('/participants')
+    cy.get('[data-cy="invite-button"]').click()
+    cy.get('[data-cy="email-field"]').trigger('paste', {
+      bubbles: true,
+      cancelable: true,
+      clipboardData: { getData: (type) => 'email1@g.co\nEmAiL1@G.cO' },
+    })
+    cy.get('[data-cy="recipients-list"]')
+      .should('contain.text', 'email1@g.co')
+      .should('not.contain.text', 'EmAiL1@G.cO')
+  })
+
   it('Can paste invites with external ID', () => {
     cy.visit('/participants')
     cy.get('[data-cy="invite-button"]').click()

--- a/application/admin-client/src/components/InviteModal.tsx
+++ b/application/admin-client/src/components/InviteModal.tsx
@@ -23,6 +23,49 @@ interface InviteModalProps {
   initialRecipients?: Recipient[]
 }
 
+type RecipientInput = { email: string; externalId?: string }
+
+// Parse paste helper
+const parsePastedText = (text: string): RecipientInput[] => {
+  return text
+    .split('\n')
+    .map((line) => {
+      // split by comma if it exists, otherwise fall back to tab
+      const split = line.includes(',') ? line.split(',') : line.split('\t')
+      return {
+        email: split[0],
+        externalId: split[1]?.trim(),
+      }
+    })
+    .filter((entry) => entry.email !== '') // Drop empty lines
+}
+
+// email dedupe and validate helper
+const getUpdatedRecipients = (
+  currentRecipients: Recipient[],
+  newEntries: RecipientInput[],
+  isValidEmail: (email: string) => boolean,
+): { updatedRecipients: Recipient[]; hasInvalidEmails: boolean } => {
+  const updatedRecipients = [...currentRecipients]
+  let hasInvalidEmails = false
+  const seenEmails = new Set(updatedRecipients.map((r) => r.email.toLowerCase()))
+
+  newEntries.forEach((entry) => {
+    const normalisedEmail = (entry.email || '').trim().toLowerCase()
+
+    if (!isValidEmail(normalisedEmail)) {
+      hasInvalidEmails = true
+    } else if (!seenEmails.has(normalisedEmail)) {
+      seenEmails.add(normalisedEmail)
+      updatedRecipients.push({
+        email: normalisedEmail,
+        prefill: { studyParticipant: { externalId: entry.externalId } },
+      })
+    }
+  })
+  return { updatedRecipients, hasInvalidEmails }
+}
+
 export function InviteModal({ onSend, onCancel, initialRecipients = [] }: InviteModalProps) {
   const validateEmail = (email: string) => {
     const r = new RegExp(emailRegex) //eslint-disable-line
@@ -41,17 +84,31 @@ export function InviteModal({ onSend, onCancel, initialRecipients = [] }: Invite
   const studyId = useCurrentStudyId()
 
   const handleAdd = () => {
-    if (!validateEmail(fieldValue)) {
+    const { updatedRecipients, hasInvalidEmails } = getUpdatedRecipients(
+      recipients,
+      [{ email: fieldValue, externalId: idFieldValue }],
+      validateEmail,
+    )
+
+    if (hasInvalidEmails) {
       setInvalid(true)
-    } else if (!emails.includes(fieldValue)) {
-      setRecipients((current) => {
-        const c = structuredClone(current)
-        c.push({ email: fieldValue, prefill: { studyParticipant: { externalId: idFieldValue } } })
-        return c
-      })
+    } else {
+      setRecipients(updatedRecipients)
       setFieldValue('')
       setIdFieldValue('')
+      setInvalid(false)
     }
+  }
+
+  const handlePaste = (event: React.ClipboardEvent) => {
+    event.preventDefault()
+    const pastedText = event.clipboardData.getData('Text')
+    const parsedEntries = parsePastedText(pastedText)
+
+    setRecipients((current) => {
+      const { updatedRecipients } = getUpdatedRecipients(current, parsedEntries, validateEmail)
+      return updatedRecipients
+    })
   }
 
   useEffect(() => {
@@ -67,29 +124,6 @@ export function InviteModal({ onSend, onCancel, initialRecipients = [] }: Invite
       setInvalid(!validateEmail(fieldValue))
     }
   }, [fieldValue])
-
-  const handlePaste = (event: React.ClipboardEvent) => {
-    event.preventDefault()
-    const pasted = event.clipboardData.getData('Text').split('\n')
-    setRecipients((current) => {
-      const c = structuredClone(current)
-      for (const p of pasted) {
-        let split = p.split(',')
-        if (split.length == 1) {
-          split = split[0].split('\t')
-        }
-        const email = split[0]
-        let id
-        if (split.length > 1) {
-          id = split[1]
-        }
-        if (!emails.includes(email) && validateEmail(email)) {
-          c.push({ email, prefill: { studyParticipant: { externalId: id } } })
-        }
-      }
-      return c
-    })
-  }
 
   const { html: emailPreview } = previewParticipantInviteEmail(
     'http://exampleregisterurl',

--- a/application/backend/prisma/schema.prisma
+++ b/application/backend/prisma/schema.prisma
@@ -18,7 +18,7 @@ model User {
   middleName          String? /// @encrypted
   lastName            String /// @encrypted
   email               String               @unique /// @encrypted
-  emailHash           String?              @unique /// @encryption:hash(email)
+  emailHash           String?              @unique /// @encryption:hash(email)?normalize=lowercase
   password            String
   role                Role                 @default(Participant)
   adminOfStudies      Study[]
@@ -181,7 +181,7 @@ model SurveyVersionAnswers {
 model Invite {
   id        String       @id @default(uuid())
   email     String /// @encrypted
-  emailHash String? /// @encryption:hash(email)
+  emailHash String? /// @encryption:hash(email)?normalize=lowercase
   status    InviteStatus @default(PENDING)
   studyId   Int
   study     Study        @relation(fields: [studyId], references: [id], onDelete: Cascade)

--- a/application/backend/src/controllers/AuthController.test.ts
+++ b/application/backend/src/controllers/AuthController.test.ts
@@ -256,6 +256,36 @@ describe('AuthController', () => {
         Number: { message: 'Password must contain at least one number' },
       })
     })
+
+    it('should save emails as lowercase in DB', async () => {
+      const upperCaseEmail = 'NewUser@Example.Com'
+      const lowerCaseEmail = 'newuser@example.com'
+
+      const registerRequest: RegisterRequest = {
+        firstName: 'John',
+        lastName: 'Doe',
+        email: upperCaseEmail,
+        password: 'Password123',
+        role: Role.Participant,
+      }
+
+      // Register user
+      const response = await request(app)
+        .post('/auth/register')
+        .set({ Authorization: `Bearer ${orgAdminToken}` })
+        .send(registerRequest)
+      expect(response.status).toEqual(201)
+      const body: RegisterResponse = response.body
+      expect(body.token).not.toBeNull()
+
+      // Attempt to register someone with uppercase version of same email
+      const lowerResponse = await request(app)
+        .post('/auth/register')
+        .set({ Authorization: `Bearer ${orgAdminToken}` })
+        .send({ ...registerRequest, email: lowerCaseEmail })
+      expect(lowerResponse.status).toEqual(500) // Not expected to work due to being a duplicate
+      expect(lowerResponse.body.message).toEqual('emailHash already in use')
+    })
   })
 
   describe('POST /auth/register/setup', () => {
@@ -274,6 +304,7 @@ describe('AuthController', () => {
         .post('/auth/register/setup')
         .send({ email: 'testadmin@test.com', password: 'abDFS141@!' })
       expect(res.ok).toBe(false)
+      expect(res.body.details).toEqual('CTRL is already set up')
     })
   })
 

--- a/application/backend/src/controllers/AuthController.ts
+++ b/application/backend/src/controllers/AuthController.ts
@@ -90,6 +90,7 @@ export class AuthController extends Controller {
     }
 
     const hashedPassword = await hashPassword(password)
+    // Note: email is stored as lowercase (see User model in `application/backend/prisma/schema.prisma`)
     const insertedUser: User = await this.userRepo.create({
       data: {
         ...userDetails,

--- a/application/backend/src/controllers/ParticipantsController.test.ts
+++ b/application/backend/src/controllers/ParticipantsController.test.ts
@@ -585,6 +585,44 @@ describe('InvitesController', () => {
       // Reset mock for other tests
       mockNodeMailer.mock.reset()
     })
+
+    it('should not create new study invites for uppercase and lowercase versions of the same email', async () => {
+      const lowerCaseEmail = 'invite5@new.com'
+      const upperCaseEmail = 'iNvItE5@NeW.cOm'
+
+      const recipients = [
+        { email: lowerCaseEmail, prefill: {} },
+        { email: upperCaseEmail, prefill: {} },
+      ]
+
+      const response = await request(app)
+        .post('/studies/1/invites')
+        .send({ recipients, subjectText: 'Subject Text', explanatoryText: 'Explanatory Text' })
+        .set({ Authorization: `Bearer ${organisationAdminToken}` })
+
+      const body: InviteParticipantsResponse = response.body
+      expect(response.status).toBe(200)
+
+      expect(body.newInvitesCount).toBe(1) // NOT TWO!!
+
+      // Check emails were successfully sent
+      const sentEmails = mockNodeMailer.mock.getSentMail()
+      expect(sentEmails.length).toBe(1) // NOT TWO!!
+
+      const sentEmail = sentEmails[0]
+      expect(sentEmail.from).toBe(`CTRL <noreply@${process.env.HOSTNAME}>`)
+      expect(sentEmail.subject).toBe('Subject Text')
+      expect(sentEmail.html).toContain('Explanatory Text')
+      expect(sentEmail.to).toBe(lowerCaseEmail)
+
+      const allCreatedInvites = await prisma.invite.findMany({
+        where: {
+          studyId: 1,
+          email: lowerCaseEmail,
+        },
+      })
+      expect(allCreatedInvites.length).toBe(1)
+    }, 100000)
   })
 
   describe('POST /studies/{studyId}/invites/resend', () => {

--- a/application/backend/src/controllers/ParticipantsController.ts
+++ b/application/backend/src/controllers/ParticipantsController.ts
@@ -689,8 +689,21 @@ export class InvitesController extends Controller {
       data: { inviteEmailSubject: subjectText, inviteEmailText: explanatoryText },
     })
 
-    const recipients = [...new Set(bodyRequest.recipients)]
-    const emails = recipients.map((val) => val.email)
+    const uniqueRecipientsMap = new Map()
+
+    bodyRequest.recipients.forEach((recipient) => {
+      const normalisedEmail = (recipient.email || '').trim().toLowerCase()
+
+      if (normalisedEmail && !uniqueRecipientsMap.has(normalisedEmail)) {
+        uniqueRecipientsMap.set(normalisedEmail, {
+          ...recipient,
+          email: normalisedEmail, // overwrite with normalised version
+        })
+      }
+    })
+
+    const recipients = Array.from(uniqueRecipientsMap.values())
+    const emails = Array.from(uniqueRecipientsMap.keys())
 
     const expiresAt = inviteExpiresAt()
 


### PR DESCRIPTION
Resolves #825 and resolves #542 

### Context

This PR has a bit of a strange origin story:

Last year, I was doing some testing and was able to create separate accounts for: joe@test.com; Joe@test.com; and joe@Test.com: https://github.com/Garvan-Data-Science-Platform/ctrl/issues/542 At some part of the app there was a search for duplicate emails, and given I was was able to create separate accounts I figured the duplicate email search should be case sensitive (backed up by some stackoverflow answers on a related question - it turns out the spec for emails is not very specific).

However, when we were getting CTRL Pen tested I encountered an issue of incompatibility with Auth0's behaviour of saving emails as lowercase: https://github.com/Garvan-Data-Science-Platform/ctrl/issues/825

On the basis of this we decided to also store emails as lowercase in CTRL. Emails are encypted at rest (using the [prisma-field-encryption](https://github.com/47ng/prisma-field-encryption/blob/next/README.md) library. There is also an `emailHash` field to stores a hash of the email to allow for index creation and unique checks: e.g. `CREATE UNIQUE INDEX "User_emailHash_key" ON "User"("emailHash");`

### Tests and code fixes

#### AuthController

- `application/backend/src/controllers/AuthController.test.ts` to check that registering an admin fails with `emailHash already in use` when an existing admin exists with an uppercase version of the email. Evidence of failing Auth test:
<img width="2204" height="1402" alt="image" src="https://github.com/user-attachments/assets/97e7073f-7ff1-4c99-ab7f-489d49712cc8" />

- Key code fix is in `application/backend/prisma/schema.prisma` to normalise the User `emailHash`, but an explanatory note is also included in `application/backend/src/controllers/AuthController.ts`

#### ParticipantsController

- `application/backend/src/controllers/ParticipantsController.test.ts` to check that when creating a batch of invites, emails with different cases do not result in two separate invites.

- Key fixes are in:
  - `application/backend/src/controllers/ParticipantsController.ts` to normalise email to lowercase when creating Invites for participants
  - `application/backend/prisma/schema.prisma` to normalise the Invites `emailHash`

#### Admin-portal invite Modal

- `application/admin-client/cypress/e2e/invites.cy.js` test to ensure that only lowercase emails are added to recipients list by typing and pasting.

- `application/admin-client/src/components/InviteModal.tsx` I did a bit of a refactor to simplify and clarify the logic for adding by typing vs adding by pasting and carve out some helper functions.

**Note**: if you do not `make clean` then `yarn dev` and `make seed` then you may encounter errors due to prisma schema changes. You might need to run `yarn prisma:generate` to recreate the prisma client.

I also created another issue (https://github.com/Garvan-Data-Science-Platform/ctrl/issues/890) to add invites for dev and test users. Without invites there is a chance for weird states to exist (e.g. a users should have an 'Accepted' invite) and we probably need tests for them!