### PR TITLE
Update e2e test to use new test data

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -61,7 +61,7 @@ jobs:
           cache: 'yarn'
       - run: yarn install
       - name: Run Tests
-        run: yarn workspace ${{ matrix.workspace }} test
+        run: yarn workspace ${{ matrix.workspace }} test:ci
       - uses: actions/upload-artifact@v4
         if: failure()
         with:

--- a/application/admin-client/package.json
+++ b/application/admin-client/package.json
@@ -60,6 +60,7 @@
     "cy:open": "cypress open",
     "cypress": "CYPRESS_MODE=open bash scripts/run_tests.sh",
     "test": "CYPRESS_MODE=run bash scripts/run_tests.sh",
+    "test:ci": "yarn run test",
     "cy:run": "cypress run"
   },
   "browserslist": {

--- a/application/backend/package.json
+++ b/application/backend/package.json
@@ -7,6 +7,7 @@
     "type-check": "tsc -b",
     "lint": "eslint .",
     "test": "bash scripts/run_tests.sh",
+    "test:ci": "yarn run test",
     "tsoa:spec": "tsoa spec",
     "tsoa:routes": "tsoa routes",
     "build-docs": "yarn run tsoa:routes && yarn run tsoa:spec && tsx scripts/replace-refs.ts",

--- a/application/common/cypress/support/commands.ts
+++ b/application/common/cypress/support/commands.ts
@@ -33,8 +33,8 @@ Cypress.Commands.add('uploadCommonFile', (selector, fileName) => {
  */
 Cypress.Commands.add('loginAdminUI', () => {
   cy.visit(AppUrls.ADMIN_CLIENT)
-  cy.get('input[name="email"]').type(TestUsers.ADMIN.email)
-  cy.get('input[name="password"]').type(TestUsers.ADMIN.password)
+  cy.get('input[name="email"]').type(TestUsers.ORG_ADMIN.email)
+  cy.get('input[name="password"]').type(TestUsers.ORG_ADMIN.password)
   cy.get('button[type="submit"]').click()
   cy.url().should('include', '/surveys') // Wait for redirect after successful login
 })

--- a/application/common/package.json
+++ b/application/common/package.json
@@ -8,8 +8,9 @@
     "lint": "eslint .",
     "build": "true",
     "dev": "true",
-    "test": "jest",
-    "e2e": "CYPRESS_MODE=open bash scripts/run_e2e_tests.sh"
+    "jest": "jest",
+    "e2e": "CYPRESS_MODE=open bash scripts/run_e2e_tests.sh",
+    "test": "yarn run jest && yarn run e2e"
   },
   "devDependencies": {
     "@types/winston": "^2.4.4",

--- a/application/common/package.json
+++ b/application/common/package.json
@@ -10,7 +10,8 @@
     "dev": "true",
     "jest": "jest",
     "e2e": "CYPRESS_MODE=open bash scripts/run_e2e_tests.sh",
-    "test": "yarn run jest && yarn run e2e"
+    "test": "yarn run jest && yarn run e2e",
+    "test:ci": "yarn run jest"
   },
   "devDependencies": {
     "@types/winston": "^2.4.4",

--- a/application/integrations/package.json
+++ b/application/integrations/package.json
@@ -7,7 +7,8 @@
     "lint": "eslint .",
     "build": "true",
     "dev": "true",
-    "test": "jest"
+    "test": "jest",
+    "test:ci": "yarn run test"
   },
   "workspaces": [
     "packages/*"

--- a/application/user-client/package.json
+++ b/application/user-client/package.json
@@ -11,6 +11,7 @@
     "cy:open": "cypress open",
     "cypress": "CYPRESS_MODE=open bash scripts/run_tests.sh",
     "test": "CYPRESS_MODE=run bash scripts/run_tests.sh",
+    "test:ci": "yarn run test",
     "cy:run": "cypress run"
   },
   "dependencies": {


### PR DESCRIPTION
Resolves #903 

`application/common/cypress/e2e` tests had not yet been updated to used new refactored test data.

Unfortunately this was only picked up in CI. This is because running `yarn test` in the root of the repo runs `yarn test` in each workspace, but the e2e tests were not part of the `application/common` test yarn script.

This PR fixes the Bug in the test but also edits the `application/common/package.json` to have separate `jest` and `e2e` scripts, and runs both as part of `yarn test`.