### PR TITLE
Enforce password strength check in createAdmin.ts

### DIFF
--- a/application/backend/src/utils/createAdmin.test.ts
+++ b/application/backend/src/utils/createAdmin.test.ts
@@ -15,9 +15,14 @@ describe('Test create admin script', () => {
   })
   it('Creates admin user if specified in env file', async () => {
     process.env['ORG_ADMIN_EMAIL'] = 'admin@test.com'
-    process.env['ORG_ADMIN_PASSWORD'] = 'tespassword'
+    process.env['ORG_ADMIN_PASSWORD'] = 'Ap9!hK2vBmN4qXr7'
     await createAdmin()
     const admin_users = await prisma.user.findMany({ where: { role: 'OrganisationAdmin' } })
     expect(admin_users).toHaveLength(3)
+  })
+  it('Throws if ORG_ADMIN_PASSWORD does not meet strength policy', async () => {
+    process.env['ORG_ADMIN_EMAIL'] = 'weak-admin@test.com'
+    process.env['ORG_ADMIN_PASSWORD'] = 'tespassword'
+    await expect(createAdmin()).rejects.toThrow('ORG_ADMIN_PASSWORD does not meet strength policy')
   })
 })

--- a/application/backend/src/utils/createAdmin.ts
+++ b/application/backend/src/utils/createAdmin.ts
@@ -1,3 +1,4 @@
+import { checkPasswordStrength } from 'common/src/PasswordStrength'
 import { hashPassword } from '../authentication'
 import prisma from '../PrismaClient'
 
@@ -5,6 +6,13 @@ const createAdmin = async () => {
   const admin = await prisma.user.findFirst({ where: { email: process.env['ORG_ADMIN_EMAIL'] } })
 
   if (!admin && process.env['ORG_ADMIN_PASSWORD'] && process.env['ORG_ADMIN_EMAIL']) {
+    const { isValid, fields } = checkPasswordStrength(process.env['ORG_ADMIN_PASSWORD'] as string)
+    if (!isValid) {
+      const reasons = Object.values(fields)
+        .map((f) => f.message)
+        .join(', ')
+      throw new Error(`ORG_ADMIN_PASSWORD does not meet strength policy: ${reasons}`)
+    }
     await prisma.user.create({
       data: {
         email: process.env['ORG_ADMIN_EMAIL'] as string,


### PR DESCRIPTION
Adds a password strength check inside createAdmin.ts before hashing ORG_ADMIN_PASSWORD. If the env var doesn't meet the strength policy, the deploy halts at container startup and the sysadmin sees the error in kubectl logs.

Fixes #907