### PR TITLE
More strict email address parsing (to match nodemailer)

### DIFF
--- a/application/backend/src/controllers/MailerController.test.ts
+++ b/application/backend/src/controllers/MailerController.test.ts
@@ -92,3 +92,33 @@ describe('MailerController', () => {
     })
   })
 })
+
+// Test due to nodemailer moving to more strict sender address parsing
+describe('Mailer Configuration', () => {
+  const originalHostname = process.env.HOSTNAME
+
+  beforeEach(() => {
+    jest.resetModules()
+  })
+
+  afterEach(() => {
+    process.env.HOSTNAME = originalHostname
+  })
+
+  it('should strip http:// and ports from HOSTNAME in fromAddress', async () => {
+    // non RFC-compliant environment variable
+    process.env.HOSTNAME = 'http://localhost:5173'
+
+    const mailerModule = await import('../utils/mailer')
+
+    expect(mailerModule!.fromAddress).toBe('CTRL <noreply@localhost>')
+  })
+
+  it('should handle plain domains without protocols', async () => {
+    process.env.HOSTNAME = 'production-domain.com'
+
+    const mailerModule = await import('../utils/mailer')
+
+    expect(mailerModule!.fromAddress).toBe('CTRL <noreply@production-domain.com>')
+  })
+})

--- a/application/backend/src/utils/mailer.ts
+++ b/application/backend/src/utils/mailer.ts
@@ -1,7 +1,24 @@
 import nodemailer from 'nodemailer'
 import config from '../config'
 
-export const fromAddress = `CTRL <noreply@${process.env.HOSTNAME}>`
+if (!process.env.HOSTNAME) {
+  throw new Error('process.env.HOSTNAME is required but was not provided.')
+}
+
+const hostnameEnvVar = process.env.HOSTNAME
+let mailDomain: string
+
+if (/^https?:\/\//i.test(hostnameEnvVar)) {
+  try {
+    mailDomain = new URL(hostnameEnvVar).hostname
+  } catch (err: any) {
+    throw new Error(`HOSTNAME deployment variable not configured. ${err}`)
+  }
+} else {
+  mailDomain = hostnameEnvVar
+}
+
+export const fromAddress = `CTRL <noreply@${mailDomain}>`
 
 export async function createMailerTransporter() {
   if (process.env.STUB_MAILER == 'true') {


### PR DESCRIPTION
Resolves #909

From a slack discussion internally:

_"Now looking at this code, I can't see how it possibly worked in the past!! As per the screenshot below, the HOSTNAME would include http:// which isn't a valid domain. My only idea was that maybe a library changed which enforced a more strict parsing._

_I was hunting though our package.json and yarn.lock for libraries that might have changed, but our smtp is provided by Ethereal in dev and: checkout their fancy new updated website: https://ethereal.email/ and there is a new update to nodemailer from July 29th with changes that mean that it isn't silently dropping special characters anymore (see second screenshot)._

_Anyway, I think this is super interesting and am pleased it isn't anything to do with us. I guess the moral of the story is to not rely on special behaviour and try to provide the most specific data whereever possible"_

Adds a test to verify the error, and a fix.