### PR TITLE
Fix nok_first prefill to use nextOfKin.firstName in Register.tsx

### DIFF
--- a/application/user-client/src/pages/Register.tsx
+++ b/application/user-client/src/pages/Register.tsx
@@ -110,7 +110,7 @@ export default function Register() {
               postcode: prefillProfile.postcode ?? '',
               mobile: prefillProfile.mobile ?? '',
               preferredContact: prefillProfile.preferredContact ?? ('MOBILE' as ContactMethod),
-              nok_first: prefillProfile.nextOfKin?.lastName ?? '',
+              nok_first: prefillProfile.nextOfKin?.firstName ?? '',
               nok_surname: prefillProfile.nextOfKin?.lastName ?? '',
               nok_email: prefillProfile.nextOfKin?.email ?? '',
               dependents: prefillProfile.dependents ?? [],


### PR DESCRIPTION
Fixes #923.

One-word fix on line 113 of `application/user-client/src/pages/Register.tsx`. `nok_first` (next-of-kin First Name field) was being prefilled from `nextOfKin?.lastName`. Changed to `nextOfKin?.firstName`.

Since the fix is at the rendering layer, it uniformly covers every upstream prefill path (CSV import wizard, direct API, RedCap integration).
