### PR TITLE
Fix getUserById to omit password and emailHash from response

### DIFF
--- a/application/backend/src/controllers/UsersController.test.ts
+++ b/application/backend/src/controllers/UsersController.test.ts
@@ -155,25 +155,27 @@ describe('UsersController', () => {
     })
 
     it('should not return user password', async () => {
+      const userId = TestUsers.PARTICIPANT_UNANSWERED.id
       const response = await request(app)
-        .get('/users')
+        .get(`/users/${userId}`)
         .set({ Authorization: `Bearer ${orgAdminToken}` })
       expect(response.status).toBe(200)
 
-      const body: GetAllUsersResponse = response.body
+      const body: GetUserByIdResponse = response.body
       expect(body).toHaveProperty('data')
-      expect(body.data[0]).not.toHaveProperty('password')
+      expect(body.data).not.toHaveProperty('password')
     })
 
     it('should not return user emailHash', async () => {
+      const userId = TestUsers.PARTICIPANT_UNANSWERED.id
       const response = await request(app)
-        .get('/users')
+        .get(`/users/${userId}`)
         .set({ Authorization: `Bearer ${orgAdminToken}` })
       expect(response.status).toBe(200)
 
-      const body: GetAllUsersResponse = response.body
+      const body: GetUserByIdResponse = response.body
       expect(body).toHaveProperty('data')
-      expect(body.data[0]).not.toHaveProperty('emailHash')
+      expect(body.data).not.toHaveProperty('emailHash')
     })
   })
 

--- a/application/backend/src/controllers/UsersController.ts
+++ b/application/backend/src/controllers/UsersController.ts
@@ -151,6 +151,7 @@ export class UsersController extends Controller {
     const user: UserResponse | null = await this.userRepo.findUnique({
       where: { id: userId },
       include: { adminOfStudies: { select: { name: true, id: true } } },
+      omit: { password: true, emailHash: true },
     })
     if (!user) {
       const errorMessage: string = `User with ID: ${userId} not found`


### PR DESCRIPTION
Fixes #921.

`GET /users/{userId}` in `application/backend/src/controllers/UsersController.ts` was returning the raw bcrypt `password` hash and `emailHash` fields in the response body. Any authenticated `OrganisationAdmin` or `StudyAdmin` could retrieve any user's password hash by calling the endpoint with their user id.

PR #878 (Constrain User api response) fixed this class of bug for `/users`, `/users/admin`, and `/users/admin/deleted` by adding `omit: { password: true, emailHash: true }` to the Prisma queries. On this endpoint it updated the return type from `User` to `UserResponse` (= `Omit<User, 'password' | 'emailHash'>`) but the `omit` clause itself wasn't added to the `findUnique` call. So the declared response shape didn't match the runtime response.

### Fix

Add `omit: { password: true, emailHash: true }` to the `findUnique` call in `getUserById`, matching the pattern the other three endpoints already use.

### Test repair

The two omit-tests in the `GET /users/:id` describe block were not hitting the right endpoint. They called `/users` (list) instead of `/users/{userId}`, typed the body as `GetAllUsersResponse`, and asserted `body.data[0]`. So they passed regardless of what `getUserById` did, which is why #878's own CI didn't catch this leak.

Fixed to:

- Hit `` `/users/${userId}` `` using `TestUsers.PARTICIPANT_UNANSWERED.id`, the same fixture the neighbouring `should return a user by ID` test already uses.
- Type the body as `GetUserByIdResponse` and assert on `body.data` (single object, not array).

### Verification

Swagger screenshot attached below.
<img width="1450" height="1198" alt="image" src="https://github.com/user-attachments/assets/b58b1ab4-369f-42dc-abde-f53d499b997d" />
