### PR TITLE
Replace stale ctrl-next references left over from repo rename

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ seed:
 	yarn prisma:seed
 
 clean: db-down
-	NODE_VERSION=$(NODE_VERSION) docker volume rm ctrl-next_ctrl-db
+	NODE_VERSION=$(NODE_VERSION) docker volume rm ctrl_ctrl-db
 
 # Local deployment via minikube and helm
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
   Dynamic Consent Management Platform
 
-  [![Build checks](https://github.com/Garvan-Data-Science-Platform/ctrl-next/actions/workflows/check.yml/badge.svg)](https://github.com/Garvan-Data-Science-Platform/ctrl-next/actions/workflows/check.yml)
+  [![Build checks](https://github.com/Garvan-Data-Science-Platform/ctrl/actions/workflows/check.yml/badge.svg)](https://github.com/Garvan-Data-Science-Platform/ctrl/actions/workflows/check.yml)
 
   <div>
     <a href="https://ctrldemo.dsp.garvan.org.au/login"><b>Participant Portal Demo</b></a>
@@ -82,7 +82,7 @@ The use of `nvm` to manage node versions is highly recommended. Install `nvm` us
 
 Docker is required to run this project locally to containerise and manage the application's services, including the frontend clients (user-client, admin-client), backend API, and supporting services like PostgreSQL. Each main component has its own Dockerfile for building optimised images, and docker-compose.yml is used to orchestrate local environments, making it easy to spin up, test, and manage dependencies consistently across different setups.
 
-Then from the root of the `ctrl-next` repository run the following commands:
+Then from the root of the `ctrl` repository run the following commands:
 
 ```bash
 # Install the required node version, will do nothing if already installed.
@@ -213,6 +213,6 @@ CTRL is also partially funded through [GUARDIANS](https://www.biocommons.org.au/
 
 ## Want to contribute?
 
-Have a look through existing [issues](https://github.com/Garvan-Data-Science-Platform/ctrl-next/issues) for anything that you could help with. If you'd like to request a feature or report a bug, please create a GitHub Issue using one of the templates provided.
+Have a look through existing [issues](https://github.com/Garvan-Data-Science-Platform/ctrl/issues) for anything that you could help with. If you'd like to request a feature or report a bug, please create a GitHub Issue using one of the templates provided.
 
-[See contribution guide &rarr;](https://github.com/Garvan-Data-Science-Platform/ctrl-next/blob/main/docs/CONTRIBUTING.md)
+[See contribution guide &rarr;](https://github.com/Garvan-Data-Science-Platform/ctrl/blob/main/docs/CONTRIBUTING.md)

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Guidance for contributing to `ctrl-next`
+# Guidance for contributing to `ctrl`
 
-- [Guidance for contributing to `ctrl-next`](#guidance-for-contributing-to-ctrl-next)
+- [Guidance for contributing to `ctrl`](#guidance-for-contributing-to-ctrl)
   - [Welcome](#welcome)
   - [Development Tooling](#development-tooling)
   - [Git + GitHub](#git--github)
@@ -38,7 +38,7 @@ Commits in `feature` branches will be squashed when merged into the `dev` branch
 Code review helps improve code quality and performance.
 
 ## Node.js
-ctrl-next uses a recent Node.js version as specified in `.nvmrc` in combination with the yarn modern package manager through corepack.
+ctrl uses a recent Node.js version as specified in `.nvmrc` in combination with the yarn modern package manager through corepack.
 
 This `.nvmrc` is the single source of truth through out this app to specify the Node Version.
 For example: Dockerfiles, `run_tests.sh` scripts, the Makefile and multiple CI workflows all parse the node version from the `.nvmrc`.


### PR DESCRIPTION
Fixes #913.

The repo was renamed from `ctrl-next` to `ctrl` at some point, and stale references were left behind in three files. Docker prefixes volume names with the project directory name, so the actual volume is `ctrl_ctrl-db` (confirmed via `docker volume ls`), but the Makefile was still trying to remove `ctrl-next_ctrl-db`, which is why `make clean` failed with `no such volume`.

Per @plouka13's follow-up comment on the issue ("should look for any other stale content in ctrl around `ctrl-next`"), I did a broader sweep with ripgrep. Eight stale references across three files:

```
./README.md
7:  [![Build checks](https://github.com/Garvan-Data-Science-Platform/ctrl-next/actions/workflows/check.yml/badge.svg)](https://github.com/Garvan-Data-Science-Platform/ctrl-next/actions/workflows/check.yml)
85:Then from the root of the `ctrl-next` repository run the following commands:
216:Have a look through existing [issues](https://github.com/Garvan-Data-Science-Platform/ctrl-next/issues) for anything that you could help with. If you'd like to request a feature or report a bug, please create a GitHub Issue using one of the templates provided.
218:[See contribution guide &rarr;](https://github.com/Garvan-Data-Science-Platform/ctrl-next/blob/main/docs/CONTRIBUTING.md)

./docs/CONTRIBUTING.md
1:# Guidance for contributing to `ctrl-next`
3:- [Guidance for contributing to `ctrl-next`](#guidance-for-contributing-to-ctrl-next)
41:ctrl-next uses a recent Node.js version as specified in `.nvmrc` in combination with the yarn modern package manager through corepack.

./Makefile
53:	NODE_VERSION=$(NODE_VERSION) docker volume rm ctrl-next_ctrl-db
```

Replaced all `ctrl-next` with `ctrl` in place across those three files. After the fix, `rg "ctrl-next" .` returns no matches. Also verified `make clean` now runs end-to-end without the volume error.
